### PR TITLE
Allow BLE file transfer to work with files > 4K

### DIFF
--- a/adafruit-ble-file-transfer.js
+++ b/adafruit-ble-file-transfer.js
@@ -29,13 +29,13 @@ const FLAG_DIRECTORY = 0x01;
 const BYTES_PER_WRITE = 20;
 
 class FileTransferClient {
-    constructor(bleDevice) {
+    constructor(bleDevice, bufferSize=4096) {
         this._resolve = null;
         this._reject = null;
         this._command = ANY_COMMAND;
         this._offset = 0;
         // We have a ton of memory so just buffer everything :-)
-        this._buffer = new Uint8Array(4096);
+        this._buffer = new Uint8Array(bufferSize);
         this._transfer = null;
         this._device = bleDevice;
         bleDevice.addEventListener("gattserverdisconnected", this.onDisconnected.bind(this));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adafruit/ble-file-transfer",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adafruit/ble-file-transfer",
-      "version": "0.9.1",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
-  "version": "0.9.1",
+  "version": "1.0.0",
   "description": "WebBluetooth library for transferring files over BLE",
   "main": "adafruit-ble-file-transfer.js",
   "dependencies": {


### PR DESCRIPTION
I found that BLE file transfer was crashing when working with larger files. Rather than hard code the value, this allows the value to be set at instantiation, with the default being the old hard coded value for backwards compatibility.