### PR TITLE
Fix mislabeled status code 0x05: STATUS_ERROR_USB_MOUNTED -> STATUS_ERROR_READONLY

### DIFF
--- a/adafruit-ble-file-transfer.js
+++ b/adafruit-ble-file-transfer.js
@@ -20,7 +20,7 @@ const MOVE_STATUS = 0x61;
 
 const STATUS_OK = 0x01;
 const STATUS_ERROR = 0x02;
-const STATUS_ERROR_USB_MOUNTED = 0x05;
+const STATUS_ERROR_READONLY = 0x05;
 
 // Flags
 const FLAG_DIRECTORY = 0x01;
@@ -208,8 +208,8 @@ class FileTransferClient {
         let chunkOffset = payload.getUint32(4, true);
         let freeSpace = payload.getUint32(16, true);
         if (status != STATUS_OK) {
-            if (status == STATUS_ERROR_USB_MOUNTED) {
-                this._reject("Unable to write while USB connected");
+            if (status == STATUS_ERROR_READONLY) {
+                this._reject("Filesystem is read-only");
             } else if (status == STATUS_ERROR) {
                 this._reject("Invalid Path");
             } else {
@@ -246,8 +246,8 @@ class FileTransferClient {
         let totalLength = payload.getUint32(8, true);
         let chunkLength = payload.getUint32(12, true);
         if (status != STATUS_OK) {
-            if (status == STATUS_ERROR_USB_MOUNTED) {
-                this._reject("Unable to read while USB connected");
+            if (status == STATUS_ERROR_READONLY) {
+                this._reject("Filesystem is read-only");
             } else if (status == STATUS_ERROR) {
                 this._reject("Invalid Path");
             } else {
@@ -305,8 +305,8 @@ class FileTransferClient {
         let i = payload.getUint32(4, true);
         let totalItems = payload.getUint32(8, true);
         if (status != STATUS_OK) {
-            if (status == STATUS_ERROR_USB_MOUNTED) {
-                this._reject("Unable to read while USB connected");
+            if (status == STATUS_ERROR_READONLY) {
+                this._reject("Filesystem is read-only");
             } else if (status == STATUS_ERROR) {
                 this._reject("Invalid Path");
             } else {
@@ -383,8 +383,8 @@ class FileTransferClient {
         }
 
         if (status != STATUS_OK) {
-            if (status == STATUS_ERROR_USB_MOUNTED) {
-                this._reject("Unable to write while USB connected");
+            if (status == STATUS_ERROR_READONLY) {
+                this._reject("Filesystem is read-only");
             } else if (status == STATUS_ERROR) {
                 this._reject("Invalid Path");
             } else {
@@ -408,8 +408,8 @@ class FileTransferClient {
 
         let status = payload.getUint8(1);
         if (status != STATUS_OK) {
-            if (status == STATUS_ERROR_USB_MOUNTED) {
-                this._reject("Unable to write while USB connected");
+            if (status == STATUS_ERROR_READONLY) {
+                this._reject("Filesystem is read-only");
             } else if (status == STATUS_ERROR) {
                 this._reject("File or Folder not found");
             } else {
@@ -433,8 +433,8 @@ class FileTransferClient {
 
         let status = payload.getUint8(1);
         if (status != STATUS_OK) {
-            if (status == STATUS_ERROR_USB_MOUNTED) {
-                this._reject("Unable to write while USB connected");
+            if (status == STATUS_ERROR_READONLY) {
+                this._reject("Filesystem is read-only");
             } else if (status == STATUS_ERROR) {
                 this._reject("Unable to move file");
             } else {


### PR DESCRIPTION
## Summary

Renames the mislabeled status code `STATUS_ERROR_USB_MOUNTED` (0x05) to `STATUS_ERROR_READONLY` and updates the user-facing rejection messages to match what the CircuitPython firmware actually means by this code.

## Why

The firmware defines status `0x05` as `STATUS_ERROR_READONLY` (see [`file_transfer_protocol.h`](https://github.com/adafruit/circuitpython/blob/main/supervisor/shared/bluetooth/file_transfer_protocol.h)):

```c
#define STATUS_ERROR_NO_FILE  0x03
#define STATUS_ERROR_PROTOCOL 0x04
#define STATUS_ERROR_READONLY 0x05
```

Looking at [`file_transfer.c`](https://github.com/adafruit/circuitpython/blob/main/supervisor/shared/bluetooth/file_transfer.c), the firmware returns `STATUS_ERROR_READONLY` whenever `filesystem_lock(active_mount)` fails — for **any** reason. That includes:

- USB MSC has the filesystem locked
- Device-side code holds the lock
- The mount is read-only (e.g. `storage.remount("/", readonly=True)`)
- Any other condition that prevents acquiring the write lock

This library currently labels that code `STATUS_ERROR_USB_MOUNTED` and rejects the promise with `"Unable to write while USB connected"`. That message is misleading: I just hit it on hardware that's running on a wall adapter with `supervisor.runtime.usb_connected == False`, no computer involved.

## Changes

- Rename internal constant `STATUS_ERROR_USB_MOUNTED` → `STATUS_ERROR_READONLY`.
- Reword reject reasons in `processWritePacing`, `processReadPacing`, `processListDirEntry`, `processMkDirStatus`, `processDeleteStatus`, and `processMoveStatus`:
  - `"Unable to write while USB connected"` → `"Filesystem is read-only"`
  - `"Unable to read while USB connected"` → `"Filesystem is read-only"`

## Compatibility

- The constant is internal (not exported), so renaming it is non-breaking for consumers.
- The error string is part of the rejection's message text. I checked [`circuitpython/web-editor`](https://github.com/circuitpython/web-editor) (the main consumer) and it does not pattern-match on the old text. Other consumers that match on the literal string would need to update.

No version bump in `package.json` — leaving that to the maintainers.
